### PR TITLE
Ajout des méthodes listen et play

### DIFF
--- a/audio/audio_manager.py
+++ b/audio/audio_manager.py
@@ -5,6 +5,7 @@ import numpy as np
 import wave
 import os
 import alsaaudio
+import uuid
 
 class AudioManager:
     def __init__(self, config):
@@ -78,6 +79,15 @@ class AudioManager:
                     sd.sleep(int(wf.getnframes() / wf.getframerate() * 1000))
         except Exception as e:
             print("Erreur lecture audio:", e)
+
+    def listen(self, duration=None):
+        """Enregistre un fichier audio temporaire et renvoie son chemin."""
+        tmp_path = f"/tmp/listen_{uuid.uuid4().hex}.wav"
+        return self.record_audio(tmp_path, duration)
+
+    def play(self, file_path):
+        """Lecture d'un fichier audio via l'appareil de sortie."""
+        self.play_audio(file_path)
 
     def scan_audio_devices(self):
         return {


### PR DESCRIPTION
## Résumé
- ajout des méthodes `listen` et `play` dans `audio/audio_manager.py`
- ces méthodes s'appuient respectivement sur `record_audio` et `play_audio`

## Tests
- `python -m py_compile audio/audio_manager.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688296e67ff8832494cdf75b409098f5