### PR TITLE
Use context manager in STTClient

### DIFF
--- a/api_clients/stt.py
+++ b/api_clients/stt.py
@@ -10,9 +10,10 @@ class STTClient:
     def transcribe(self, wav_path):
         if not self.api_key or not self.endpoint:
             return ""
-        files = {'file': open(wav_path, 'rb')}
         headers = {'Authorization': f"Bearer {self.api_key}"}
-        response = requests.post(self.endpoint, files=files, headers=headers)
+        with open(wav_path, "rb") as f:
+            files = {"file": f}
+            response = requests.post(self.endpoint, files=files, headers=headers)
         if response.status_code == 200:
             return response.json().get("text", "")
         return ""


### PR DESCRIPTION
## Summary
- ensure STTClient.transcribe closes the wav file automatically

## Testing
- `python -m py_compile api_clients/stt.py`


------
https://chatgpt.com/codex/tasks/task_e_688297831c908324a1c439fb27dc1ab0