### PR TITLE
Mise à jour pour écran SPI 2.8"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,18 @@ faces/
 
 Vous pouvez modifier ces valeurs via le panneau de paramètres accessible depuis
 l'interface principale.
+
+## \U0001F5A5\uFE0F Utilisation sur NanoPi Neo + \u00e9cran SPI 2.8"
+
+Un script de lancement est fourni pour utiliser directement le framebuffer de l'\u00e9cran SPI.
+
+```bash
+chmod +x scripts/run_spi_screen.sh
+./scripts/run_spi_screen.sh
+```
+
+Par d\u00e9faut, il utilise `/dev/fb1`. Pour un autre framebuffer :
+
+```bash
+QT_QPA_FB=/dev/fb0 ./scripts/run_spi_screen.sh
+```

--- a/scripts/run_spi_screen.sh
+++ b/scripts/run_spi_screen.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Lance l'application en utilisant le framebuffer SPI
+# Utiliser QT_QPA_FB pour définir le framebuffer si différent de /dev/fb1
+export QT_QPA_PLATFORM=linuxfb
+export QT_QPA_FB=${QT_QPA_FB:-/dev/fb1}
+python3 "$(dirname "$0")/../main.py"
+


### PR DESCRIPTION
## Résumé
- ajout d'un script `run_spi_screen.sh` pour lancer l'application sur un framebuffer SPI
- documentation de ce script et de son usage dans le README

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829d9bdfe8832497906b1fe4fed2a4